### PR TITLE
Make example in docs a little clearer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,35 +3,35 @@
 //! Simple, robust and pragmatic facade for JSON-RPC2 services that is transport agnostic.
 //!
 //! ```
-//! use json_rpc2::*;
+//! use json_rpc2::{Request, Response, Result, Server, Service};
 //! use serde_json::Value;
 //!
 //! struct ServiceHandler;
 //! impl Service for ServiceHandler {
-//!    type Data = ();
-//!    fn handle(&self, request: &Request, _ctx: &Self::Data) -> Result<Option<Response>> {
-//!        let response = match request.method() {
-//!          "hello" => {
-//!            let params: String = request.deserialize()?;
-//!            let message = format!("Hello, {}!", params);
-//!            Some((request, Value::String(message)).into())
-//!          }
-//!          _ => None
-//!        };
-//!        Ok(response)
-//!    }
+//!     type Data = ();
+//!     fn handle(&self, request: &Request, _ctx: &Self::Data) -> Result<Option<Response>> {
+//!         let response = match request.method() {
+//!             "hello" => {
+//!                 let params: String = request.deserialize()?;
+//!                 let message = format!("Hello, {}!", params);
+//!                 Some((request, Value::String(message)).into())
+//!             }
+//!             _ => None,
+//!         };
+//!         Ok(response)
+//!     }
 //! }
 //!
 //! fn main() -> Result<()> {
-//!    let service: Box<dyn Service<Data = ()>> = Box::new(ServiceHandler {});
-//!    let request = Request::new_reply(
-//!        "hello", Some(Value::String("world".to_string())));
-//!    let server = Server::new(vec![&service]);
-//!    let response = server.serve(&request, &());
-//!    assert_eq!(
-//!        Some(Value::String("Hello, world!".to_string())),
-//!        response.unwrap().into());
-//!    Ok(())
+//!     let service: Box<dyn Service<Data = ()>> = Box::new(ServiceHandler {});
+//!     let request = Request::new_reply("hello", Some(Value::String("world".to_string())));
+//!     let server = Server::new(vec![&service]);
+//!     let response = server.serve(&request, &());
+//!     assert_eq!(
+//!         Some(Value::String("Hello, world!".to_string())),
+//!         response.unwrap().into()
+//!     );
+//!     Ok(())
 //! }
 //! ```
 //!


### PR DESCRIPTION
The glob import in the example makes it a little unclear what exactly is being imported. In particular I didn't notice the `Result` type alias initially. This PR makes the imports explicit. I also ran the example code through rustfmt.